### PR TITLE
Fix 401 Unauthorized + make language optional

### DIFF
--- a/src/apple_app_reviews_scraper.py
+++ b/src/apple_app_reviews_scraper.py
@@ -51,7 +51,7 @@ def fetch_reviews(country: str,
 
     ## Define request headers and params ------------------------------------
     landing_url = f'https://apps.apple.com/{country}/app/{app_name}/id{app_id}'
-    request_url = f'https://amp-api.apps.apple.com/v1/catalog/{country}/apps/{app_id}/reviews'
+    request_url = f'https://amp-api-edge.apps.apple.com/v1/catalog/{country}/apps/{app_id}/reviews'
 
     MAX_RETURN_LIMIT = '20'
 
@@ -66,7 +66,7 @@ def fetch_reviews(country: str,
     }
 
     params = (
-        ('l', 'fr-FR'),  # language
+        # ('l', 'fr-FR'),  # language (optional)
         ('offset', str(offset)),  # paginate this offset
         ('limit', MAX_RETURN_LIMIT),  # max valid is 20
         ('platform', 'web'),


### PR DESCRIPTION
Using the default `request_url` value causes 401 Unauthorized errors because Apple recently changed the endpoint URL. I also don't think the script should filter for any language by default, so the language parameter is commented out.